### PR TITLE
fix: jobs missing params(MAPCO-6822)

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -1,1 +1,47 @@
-{}
+{
+  "telemetry": {
+    "logger": {
+      "level": "info",
+      "prettyPrint": false
+    },
+    "tracing": {
+      "enabled": false,
+      "url": "http://telemetryUrl/tracing"
+    },
+    "metrics": {
+      "enabled": false,
+      "url": "http://telemetryUrl/metrics",
+      "interval": "3"
+    }
+  },
+  "httpRetry": {
+    "attempts": 5,
+    "delay": "exponential",
+    "shouldResetTimeout": true
+  },
+  "jobManager": {
+    "url": "http://job-manager-job-manager"
+  },
+  "workerTypes": {
+    "tiles": {
+      "jobType": "rasterTilesExporter1",
+      "taskType": "rasterTilesExporter1"
+    }
+  },
+  "storage_provider": "S3",
+  "fs": {
+    "mountDir": "/packages",
+    "subPath": ""
+  },
+  "s3": {
+    "apiVersion": "2006-03-01",
+    "endpoint": "http://localhost:9000",
+    "accessKeyId": "minioadmin",
+    "secretAccessKey": "minioadmin",
+    "sslEnabled": false,
+    "maxRetries": 3,
+    "bucket": "raster",
+    "prefix": "",
+    "batchSize": 1000
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "jest": "^29.5.0",
         "jest-create-mock-instance": "^2.0.0",
         "jest-html-reporters": "^3.1.4",
+        "nock": "^14.0.1",
         "prettier": "^2.8.4",
         "pretty-quick": "^3.1.3",
         "rimraf": "^4.4.0",
@@ -3254,6 +3255,24 @@
         "node": ">=8.12.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -3297,6 +3316,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.4.0",
@@ -12722,6 +12766,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -14418,6 +14469,21 @@
         "node": ">=v0.2.0"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.1.tgz",
+      "integrity": "sha512-IJN4O9pturuRdn60NjQ7YkFt6Rwei7ZKaOwb1tvUIIqTgeD0SDDAX3vrqZD4wcXczeEy/AsUXxpGpP/yHqV7xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.37.3",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -14699,6 +14765,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -15508,6 +15581,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/protobufjs": {
       "version": "6.11.3",
@@ -16719,6 +16802,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jest": "^29.5.0",
     "jest-create-mock-instance": "^2.0.0",
     "jest-html-reporters": "^3.1.4",
+    "nock": "^14.0.1",
     "prettier": "^2.8.4",
     "pretty-quick": "^3.1.3",
     "rimraf": "^4.4.0",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -15,3 +15,5 @@ export interface IExporterCleanupParameters {
 }
 
 export type IExporterJobResponse = IJobResponse<IExporterCleanupParameters, Record<string, unknown>>;
+
+export type IJobResponseWithoutParams = Omit<IExporterJobResponse, 'parameters'>;

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -1,0 +1,134 @@
+import jsLogger from '@map-colonies/js-logger';
+import nock from 'nock';
+import { OperationStatus } from '@map-colonies/mc-priority-queue';
+import { JobManagerClient } from '../../../src/clients/jobManagerClient';
+import { IJobResponseWithoutParams } from '../../../src/common/interfaces';
+
+describe('JobManagerClient', () => {
+  let jobManagerClient: JobManagerClient;
+  const jobManagerUrl = 'http://job-manager-job-manager';
+
+  beforeEach(() => {
+    jobManagerClient = new JobManagerClient(jsLogger({ enabled: false }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('getCompletedUncleanedJobs', () => {
+    const expectedQuery = {
+      isCleaned: false,
+      status: OperationStatus.COMPLETED,
+      shouldReturnTasks: false,
+      type: '',
+    };
+    it('calls get with correct query', async () => {
+      const getSpy = jest.spyOn(jobManagerClient as unknown as { get: jest.Func }, 'get');
+      const path = '/jobs';
+      expectedQuery.type = jobManagerClient['tilesJobType'];
+
+      nock(jobManagerUrl).get(path).query(expectedQuery).reply(200, []);
+
+      await jobManagerClient.getCompletedUncleanedJobs();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(getSpy).toHaveBeenCalledWith(path, expectedQuery);
+    });
+
+    it('returns empty array if response is undefined', async () => {
+      nock(jobManagerUrl).get('/jobs').query(expectedQuery).reply(200, undefined);
+
+      const result = await jobManagerClient.getCompletedUncleanedJobs();
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns jobs with params', async () => {
+      const jobsWithoutParams = [{ id: '1' }, { id: '2' }] as IJobResponseWithoutParams[];
+      const jobsWithParams = [
+        { id: '1', parameters: {} },
+        { id: '2', parameters: {} },
+      ];
+
+      nock(jobManagerUrl).get('/jobs').query(expectedQuery).reply(200, jobsWithoutParams);
+
+      jobsWithoutParams.forEach((job, index) => {
+        nock(jobManagerUrl).get(`/jobs/${job.id}`).reply(200, jobsWithParams[index]);
+      });
+
+      const result = await jobManagerClient.getCompletedUncleanedJobs();
+
+      expect(result).toEqual(jobsWithParams);
+    });
+  });
+
+  describe('getFailedUncleanedJobs', () => {
+    const expectedQuery = {
+      isCleaned: false,
+      status: OperationStatus.FAILED,
+      shouldReturnTasks: false,
+      type: '',
+    };
+    it('calls get with correct query', async () => {
+      const getSpy = jest.spyOn(jobManagerClient as unknown as { get: jest.Func }, 'get');
+      const path = '/jobs';
+
+      expectedQuery.type = jobManagerClient['tilesJobType'];
+
+      nock(jobManagerUrl).get(path).query(expectedQuery).reply(200, []);
+
+      await jobManagerClient.getFailedUncleanedJobs();
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      expect(getSpy).toHaveBeenCalledWith(path, expectedQuery);
+    });
+
+    it('returns empty array if response is undefined', async () => {
+      expectedQuery.type = jobManagerClient['tilesJobType'];
+
+      nock(jobManagerUrl).get('/jobs').query(expectedQuery).reply(200, undefined);
+
+      const result = await jobManagerClient.getFailedUncleanedJobs();
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns jobs with params', async () => {
+      const jobsWithoutParams = [{ id: '1' }, { id: '2' }] as IJobResponseWithoutParams[];
+      const jobsWithParams = [
+        { id: '1', parameters: {} },
+        { id: '2', parameters: {} },
+      ];
+
+      expectedQuery.type = jobManagerClient['tilesJobType'];
+
+      nock(jobManagerUrl).get('/jobs').query(expectedQuery).reply(200, jobsWithoutParams);
+
+      jobsWithoutParams.forEach((job, index) => {
+        nock(jobManagerUrl).get(`/jobs/${job.id}`).reply(200, jobsWithParams[index]);
+      });
+
+      const result = await jobManagerClient.getFailedUncleanedJobs();
+
+      expect(result).toEqual(jobsWithParams);
+    });
+  });
+
+  describe('updateCleaned', () => {
+    it('calls put with correct body', async () => {
+      const putSpy = jest.spyOn(jobManagerClient as unknown as { put: jest.Func }, 'put');
+      const jobId = '1';
+      const path = `/jobs/${jobId}`;
+      const body = { isCleaned: true };
+
+      nock(jobManagerUrl).put(path, body).reply(200);
+
+      await jobManagerClient.updateCleaned(jobId);
+
+      expect(putSpy).toHaveBeenCalledTimes(1);
+      expect(putSpy).toHaveBeenCalledWith(path, body);
+    });
+  });
+});


### PR DESCRIPTION

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔      |
| New feature     | ✖      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✖      |
| Chore           | ✖      |

Further  information:
## Description
Following the breaking changes in Job Manager v4.0.0 where job parameters are no longer included in the `/jobs` API response, this PR modifies the `getCompletedUncleanedJobs` and ` getFailedUncleanedJobs` functions to fetch job with parameters individually for each job.

## Main Changes
- Implemented parallel fetching of job parameters using `Promise.all` for optimal performance

## Impact
- **API Calls**: Increased number of API calls (one additional call per in-progress job)
- **Performance**: Minimized impact by implementing parallel fetching
